### PR TITLE
Emacs 23.4 doesn't like recursive defsubsts (js3-treeify) when byte-compiling

### DIFF
--- a/js3.el
+++ b/js3.el
@@ -7442,7 +7442,7 @@ For instance, following a 'this' reference requires a parent function node."
 ;; a nested sub-alist element looks like (INDEX-NAME SUB-ALIST).
 ;; The sub-alist entries immediately follow INDEX-NAME, the head of the list.
 
-(defsubst js3-treeify (lst)
+(defun js3-treeify (lst)
   "Convert (a b c d) to (a ((b ((c d)))))"
   (if (null (cddr lst))  ; list length <= 2
       lst


### PR DESCRIPTION
Changing js3-treeify to regular defun works ok.
