### PR TITLE
File mode specification error: (args-out-of-range 0 1) on a new file/buffer

### DIFF
--- a/js3.el
+++ b/js3.el
@@ -10710,7 +10710,8 @@ nil."
         js3-mode-comments-hidden nil
         js3-mode-buffer-dirty-p t
         js3-mode-parsing nil)
-  (js3-reparse))
+  (if (not (zerop (buffer-size)))
+      (js3-reparse)))
 
 (defun js3-mode-check-compat ()
   "Signal an error if we can't run with this version of Emacs."


### PR DESCRIPTION
A call to js3-reparse causes this error on a new file/buffer.  Upon inspection, this error is originated from `(buffer-string-no-properties 1 (buffer-size))` in `js3-do-parse`, as `(buffer-size)` of an empty buffer is 0.

Because there is nothing to parse in this case, I worked around this problem by not calling `(js3-reparse)` inside `js3-mode` when opening an empty file/buffer.
