### PR TITLE
Eliminate trailing whitespace when inserting a new line

### DIFF
--- a/js3.el
+++ b/js3.el
@@ -11014,6 +11014,7 @@ This ensures that the counts and `next-error' are correct."
 	       (not (zerop (buffer-size))))
           (let ((js3-bounce-indent-p nil))
             (js3-indent-line)))
+      (delete-horizontal-space t)
       (insert "\n")
       (if js3-enter-indents-newline
           (let ((js3-bounce-indent-p nil))


### PR DESCRIPTION
This change allows you to successfully insert a blank line when you press Enter
twice in a row.
