### PR TITLE
Make global declarations compatible with JSLint and JSHint

### DIFF
--- a/js3.el
+++ b/js3.el
@@ -11943,10 +11943,10 @@ it marks the next defun after the ones already marked."
     (when (not (member var js3-additional-externs))
       (save-excursion
 	(goto-char 0)
-	(when (not (looking-at "^/\\* global "))
+	(when (not (looking-at "^/\\*global "))
 	  (newline 1)
 	  (forward-line -1)
-	  (insert "/* global */")
+	  (insert "/*global*/")
 	  (goto-char 0))
 	(if (not (re-search-forward "[*]/" nil t))
 	    (message "Invalid global declaration")

--- a/lib/js3-foot.el
+++ b/lib/js3-foot.el
@@ -1298,10 +1298,10 @@ it marks the next defun after the ones already marked."
     (when (not (member var js3-additional-externs))
       (save-excursion
 	(goto-char 0)
-	(when (not (looking-at "^/\\* global "))
+	(when (not (looking-at "^/\\*global "))
 	  (newline 1)
 	  (forward-line -1)
-	  (insert "/* global */")
+	  (insert "/*global*/")
 	  (goto-char 0))
 	(if (not (re-search-forward "[*]/" nil t))
 	    (message "Invalid global declaration")


### PR DESCRIPTION
Some JavaScript linters don't expect whitespace before the global directive.

http://www.jslint.com/lint.html
http://www.jshint.com/docs/
