### PR TITLE
Preventing splitting string after backslash.

### DIFF
--- a/js3.el
+++ b/js3.el
@@ -11003,9 +11003,12 @@ This ensures that the counts and `next-error' are correct."
   (let ((parse-status (save-excursion
                         (parse-partial-sexp (point-min) (point)))))
     (cond
-     ;; check if we're inside a string
-     ((nth 3 parse-status)
+     ;; check if we're inside a string and not after backslash
+     ((and (nth 3 parse-status) (not (nth 5 parse-status)))
       (js3-mode-split-string parse-status))
+     ;; check if we're inside a string and after backslash
+     ((and (nth 3 parse-status) (nth 5 parse-status))
+      (js3-mode-split-string-with-backslash))
      ;; check if inside a block comment
      ((nth 4 parse-status)
       (js3-mode-extend-comment))
@@ -11020,6 +11023,23 @@ This ensures that the counts and `next-error' are correct."
       (if js3-enter-indents-newline
           (let ((js3-bounce-indent-p nil))
             (js3-indent-line)))))))
+
+(defun js3-mode-split-string-with-backslash ()
+  "Turn a newline after backslash in mid-string into backslash-newline-separated multiline string."
+  (insert "\n")
+  (js3-mode-force-backslash))
+
+(defun js3-mode-force-backslash ()
+  "Force backslash character after a line of non-terminated string."
+  (let* ((parse-status
+          (save-excursion
+            (parse-partial-sexp (point-min) (line-end-position)))))
+    (when (and
+           (not (nth 5 parse-status))
+           (nth 3 parse-status))
+      (save-excursion
+        (end-of-line)
+        (insert "\\")))))
 
 (defun js3-mode-split-string (parse-status)
   "Turn a newline in mid-string into a string concatenation."

--- a/lib/js3-foot.el
+++ b/lib/js3-foot.el
@@ -357,9 +357,12 @@ This ensures that the counts and `next-error' are correct."
   (let ((parse-status (save-excursion
                         (parse-partial-sexp (point-min) (point)))))
     (cond
-     ;; check if we're inside a string
-     ((nth 3 parse-status)
+     ;; check if we're inside a string and not after backslash
+     ((and (nth 3 parse-status) (not (nth 5 parse-status)))
       (js3-mode-split-string parse-status))
+     ;; check if we're inside a string and after backslash
+     ((and (nth 3 parse-status) (nth 5 parse-status))
+      (js3-mode-split-string-with-backslash))
      ;; check if inside a block comment
      ((nth 4 parse-status)
       (js3-mode-extend-comment))
@@ -374,6 +377,23 @@ This ensures that the counts and `next-error' are correct."
       (if js3-enter-indents-newline
           (let ((js3-bounce-indent-p nil))
             (js3-indent-line)))))))
+
+(defun js3-mode-split-string-with-backslash ()
+  "Turn a newline after backslash in mid-string into backslash-newline-separated multiline string."
+  (insert "\n")
+  (js3-mode-force-backslash))
+
+(defun js3-mode-force-backslash ()
+  "Force backslash character after a line of non-terminated string."
+  (let* ((parse-status
+          (save-excursion
+            (parse-partial-sexp (point-min) (line-end-position)))))
+    (when (and
+           (not (nth 5 parse-status))
+           (nth 3 parse-status))
+      (save-excursion
+        (end-of-line)
+        (insert "\\")))))
 
 (defun js3-mode-split-string (parse-status)
   "Turn a newline in mid-string into a string concatenation."


### PR DESCRIPTION
I fixed the behavior of splitting string.
Now when we press Enter key, if we're after a backslash, creating new string will be prevented, so we obtain backslash-newline-separated (\ \n in c-style) string.

So, when we typed something like this:
    "some\str"
… and hit RET after \ char, we obtain:
    "some\
    str"
… instead of default behavior:
    "some\"
    + "str"
… which is illegal…

Of course, my fix is safe. So, using backslashes for escaping is covered.
Even you typed something like:
    "some\\str"
… and hit RET after second slash, you will have
    "some\\"
    + "str"
… but if you type third slash after second and hit RET, you obtain
    "some\\\
   str".
