### PR TITLE
Provide the feature 'js3 so that (require 'js3) works correctly

### DIFF
--- a/js3.el
+++ b/js3.el
@@ -12001,7 +12001,7 @@ it marks the next defun after the ones already marked."
 
 (defalias 'js3r 'js3-mode-reset)
 
-(provide 'js3-mode)
+(provide 'js3)
 
 ;;; js3-foot.el ends here
 


### PR DESCRIPTION
See https://github.com/milkypostman/melpa/commit/e5c2c6145119be5522127a98cdc640c59572956a#commitcomment-3999661 for an instance of the existing code causing problems.

At your option, you might consider _also_ providing `'js3-mode`, but I can't see this change causing any problems as-is.

-Steve

/cc @knu
