### PR TITLE
Make js3-mode work with indirect buffers

### DIFF
--- a/js3-mode.el
+++ b/js3-mode.el
@@ -7949,7 +7949,7 @@ Scanner should be initialized."
            (replace-regexp-in-string
             "[\n\t ]+" " "
             (buffer-substring-no-properties
-             1 (buffer-size)) t t)))
+             (point-min) (point-max)) t t)))
       (setq js3-declared-globals
             (nconc js3-declared-globals
                    (split-string


### PR DESCRIPTION
Indirect buffer most of the time is not in range 1 to (buffer-size) so (point-min) to (point-max) is a correct way to do this.

This fixes exception when using narrow-indirect.el for <script></script> in a .html